### PR TITLE
fix: unblock global-temp scheduled commits

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,9 @@ on:
   # Allows manual triggering of the workflow
   workflow_dispatch: 
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,4 +57,4 @@ jobs:
       run: |
         git config --global user.email "${{env.CI_COMMIT_EMAIL}}"
         git config --global user.name "${{env.CI_COMMIT_NAME}}"
-        git diff --quiet && echo "No changes to commit" || (git add data/country-codes.csv && git commit -m "${{env.CI_COMMIT_MESSAGE}}" && git push)
+        git diff --quiet && echo "No changes to commit" || (git add data/*.csv && git commit -m "${{env.CI_COMMIT_MESSAGE}}" && git push)

--- a/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
+++ b/UPDATE_SCRIPT_MAINTENANCE_REPORT.md
@@ -1,0 +1,8 @@
+# Update Script Maintenance Report
+
+Date: 2026-03-03
+
+- Executed update pipeline (`make data`) to verify script path.
+- Fixed GitHub Actions commit target in `.github/workflows/actions.yml` from wrong file path to `data/*.csv`.
+- Added workflow token write permission (`permissions: contents: write`).
+- This change restores automatic commit behavior for generated temperature files.


### PR DESCRIPTION
## Summary
- fixed workflow commit target from a non-existent file path to `data/*.csv`
- added `permissions: contents: write` for scheduled push capability
- added root-level `UPDATE_SCRIPT_MAINTENANCE_REPORT.md`

## Validation
- `make data`