### PR TITLE
Switch licence from ODC-PDDL-1.0 to CC BY 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,15 @@ The processed data are output to `./data`.
 
 ## License
 
-### ODC-PDDL-1.0
+### CC BY 4.0
 
-This Data Package and these datasets are made available under the Public Domain Dedication and License v1.0 whose full text can be found at: http://www.opendatacommons.org/licenses/pddl/1.0/
+This Data Package is licensed under the [Creative Commons Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/) licence.
+
+The HadCRUT5 data is © British Crown Copyright, Met Office, provided under the [Open Government Licence v3](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/), which requires the following acknowledgement when the data are used:
+
+> HadCRUT.5.1.0.0 data were obtained from http://www.metoffice.gov.uk/hadobs/hadcrut5 and are © British Crown Copyright, Met Office, provided under an Open Government Licence, http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
+
+NASA GISTEMP data is a US Government work and is in the public domain.
 
 ## References
 

--- a/datapackage.json
+++ b/datapackage.json
@@ -2,9 +2,9 @@
   "description": "Annual and monthly global mean surface temperature anomalies in degrees Celsius, from NASA GISTEMP and UK Met Office HadCRUT5, covering 1850–present. Anomalies are relative to source-specific base periods.",
   "licenses": [
     {
-      "name": "ODC-PDDL-1.0",
-      "path": "http://opendatacommons.org/licenses/pddl/",
-      "title": "Open Data Commons Public Domain Dedication and License v1.0"
+      "name": "CC-BY-4.0",
+      "path": "https://creativecommons.org/licenses/by/4.0/",
+      "title": "Creative Commons Attribution 4.0 International"
     }
   ],
   "name": "global-temp",


### PR DESCRIPTION
## Summary

- Replace `ODC-PDDL-1.0` with `CC-BY-4.0` in `datapackage.json`
- Update the licence section in `README.md` to include the verbatim HadCRUT5 acknowledgement required by OGL v3

## Why

The dataset now uses HadCRUT5 data (© British Crown Copyright, Met Office), released under OGL v3. OGL v3 permits all reuse but **requires attribution** — a condition PDDL cannot waive because the Crown Copyright belongs to the Met Office, not this curator. Applying PDDL was misleading users into thinking there were no conditions on use.

CC BY 4.0 is [explicitly compatible with OGL v3](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/), is the de facto standard for attribution-required open data, and is more internationally recognised than OGL v3 itself. It makes the existing attribution obligation visible without adding any new burden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)